### PR TITLE
Persistência cópia de negociação no IndexedDB

### DIFF
--- a/client/js/app/controllers/NegociacaoController.js
+++ b/client/js/app/controllers/NegociacaoController.js
@@ -3,6 +3,7 @@ import { Mensagem } from '../models/Mensagem';
 import { NegociacoesView } from '../views/NegociacoesView';
 import { MensagemView } from '../views/MensagemView';
 import { NegociacaoService } from '../services/NegociacaoService';
+import { NegociacoesIndexedDBService } from '../services/NegociacoesIndexedDBService';
 import { DateHelper } from '../helpers/DateHelper';
 import { Negociacao } from '../models/Negociacao';
 
@@ -20,11 +21,18 @@ export class NegociacaoController {
         this._mensagem = new Mensagem();
         this._mensagemView = new MensagemView($("#mensagemView"));
         this._mensagemView.update(this._mensagem);
+
+        this._negociacoesIndexedDBService = new NegociacoesIndexedDBService();
     }
 
     adiciona(event) {
         event.preventDefault();
-        this._listaNegociacoes.adiciona(this._criaNegociacao());
+
+        let negociacao = this._criaNegociacao();
+
+        this._listaNegociacoes.adiciona(negociacao);
+        this._negociacoesIndexedDBService.adiciona(negociacao);
+
         this._negociacoesView.update(this._listaNegociacoes);
 
         this._mensagem.texto = "Negociação adicionada com sucesso";

--- a/client/js/app/services/IndexedDBService.js
+++ b/client/js/app/services/IndexedDBService.js
@@ -1,0 +1,140 @@
+export class IndexedDBService {
+
+  static DATABASE_NAME() { return "negociacoesdb;" };
+  static DEFAULT_VERSION() { return 1; };
+  static DEFAULT_KEY_GENERATOR() { return { autoIncrement: true }; };
+
+  constructor(objectStoreDefinitions = [], dataBaseVersion = IndexedDBService.DEFAULT_VERSION()) {
+    this._objectStoreDefinitions = objectStoreDefinitions;
+
+    this._getConnection(
+      window.indexedDB.open(
+        IndexedDBService.DATABASE_NAME(), 
+        dataBaseVersion
+      )
+    )
+    .then(connection => this._connection = connection)
+    .catch(error => {
+      console.error("Erro ao tentar carregar banco IndexedDB; ", error);
+      throw new Error("Não foi possível obter conexão com a base do IndexedDB.")
+    });
+  }
+
+  _getConnection(requestOpenDB) {
+    return new Promise( (resolve, reject) => {
+
+      // ON UPGRADE NEEDED
+      requestOpenDB.onupgradeneeded = event => {
+        console.log("OnUpgradeNeeded; Necessário criar um novo banco ou atualizar um antigo por conta de upgrade de versão.");
+
+        const connection = event.target.result;
+
+				this._objectStoreDefinitions
+					.forEach(objectStoreDefinition => {
+						if (connection.objectStoreNames.contains(objectStoreDefinition.objectStoreName)) {
+							connection.deleteObjectStore(objectStoreDefinition.objectStoreName);
+						}
+						
+						connection.createObjectStore(
+							objectStoreDefinition.objectStoreName, 
+							objectStoreDefinition.keyGenerator || IndexedDBService.DEFAULT_KEY_GENERATOR()
+						);
+					});
+      };
+
+      // ON CONNECTION SUCCESS
+      requestOpenDB.onsuccess = event => {
+        let connection = event.target.result;
+
+        console.log("Conexão obtida com sucesso", connection);
+
+        resolve( connection );
+      };
+
+      // ON CONNECTION ERROR
+      requestOpenDB.onerror = event => {
+        const error = event.target.error;
+
+        console.error("Erro ao tentar obter conexão com a base de dados", error);
+
+        reject(error);
+      };
+    });
+  }
+
+  overObjectStore(objectStoreName) {
+    const defaultAccessMode = {read: false, write: false};
+    return {
+      accessMode: (accessMode = defaultAccessMode) => this._getAccessMode(accessMode, objectStoreName),
+      doInsert: (objectInstance) => this._insert(objectInstance, defaultAccessMode, objectStoreName),
+      retrieveAll: () => this._iterateOverCursor(defaultAccessMode, objectStoreName)
+    };
+  }
+
+  _iterateOverCursor(accessMode, objectStoreName) {
+    return new Promise( (resolve, reject) => {
+      let transaction = this._getTransaction(accessMode, objectStoreName);
+
+      let store = transaction.objectStore(objectStoreName);
+
+      let cursor = store.openCursor();
+
+      let elements = [];
+
+      cursor.onsuccess = event => {
+        let current = event.target.result;
+
+        if (current) {
+          elements.push(current.value);
+
+          current.continue();
+        } else {
+          resolve(elements);
+        }
+      };
+
+      cursor.onerror = event => {
+        reject(event.target.error.name);
+      };
+    });
+  }
+
+  _getAccessMode(accessMode, objectStoreName) {
+    return {
+      doInsert: (objectInstance) => this._insert(objectInstance, accessMode, objectStoreName),
+      retrieveAll: () => this._iterateOverCursor(accessMode, objectStoreName)
+    };
+  }
+
+  _getTransaction(accessMode, objectStoreName) {
+    const parsedAccessMode = `${ accessMode.read ? "read" : "" }${ accessMode.write ? "write" : accessMode.read ? "only" : "invalidmode" }`;
+    console.log("access mode; ", parsedAccessMode);
+
+    return this._connection.transaction(
+      [objectStoreName],
+      parsedAccessMode
+    );
+  }
+
+  _insert(objectInstance, accessMode, objectStoreName) {
+    return new Promise( (resolve, reject) => {
+      let transaction = this._getTransaction(accessMode, objectStoreName);
+
+      let objectStore = transaction.objectStore(objectStoreName);
+
+      let addRequest = objectStore.add(objectInstance);
+
+      addRequest.onsuccess = event => {
+        resolve(
+          event.target.result
+        );
+      };
+
+      addRequest.onerror = event => {
+        reject(
+          event.target.result
+        );
+      };
+    });
+  }
+}

--- a/client/js/app/services/NegociacoesIndexedDBService.js
+++ b/client/js/app/services/NegociacoesIndexedDBService.js
@@ -1,0 +1,28 @@
+import { IndexedDBService } from './IndexedDBService';
+
+const NEGOCIACAO_OBJECT_STORE = "negociacoes";
+
+export class NegociacoesIndexedDBService {
+
+  constructor() {
+    this._indexedDBService = new IndexedDBService([
+      {
+        objectStoreName: NEGOCIACAO_OBJECT_STORE,
+        keyGenerator: IndexedDBService.DEFAULT_KEY_GENERATOR()
+      }
+    ]);
+  }
+
+  adiciona(negociacao) {
+    this._indexedDBService
+      .overObjectStore(NEGOCIACAO_OBJECT_STORE)
+      .accessMode({read : true, write : true})
+      .doInsert(negociacao)
+      .then(negociacaoChave => {
+        console.log("Negociação inserida com sucesso, e a chave de identificação resultante é; ", negociacaoChave);
+      })
+      .catch(erro => {
+        console.error("Erro an tentar inserir negociação; ", erro);
+      });
+  }
+}


### PR DESCRIPTION
- Foi implementado a classe IndexedDBService especializada em lidar com
  operações sob o IndexedDB, como a definição de objectStructure name e
  o schema key generator para este, e os métodos doInsert() e
  retrieveAll() que são as interfaces para lidar de fato com a classe.
- A classe NegociacoesIndexedDBService é específica para a
  inserção/cópia da negociação, tarefa esta solicitada na issue #8.
- O controller NegociacaoController recebeu alteração lidar com o
  serviços criados, e no ponto em que há a chamada para adição de uma
  negociação na lista, o serviço correspondente ao indexed db também é
  invocado.

[fix #8][issue #8]